### PR TITLE
Wire new routers + deploy script + publish workflows

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -6,6 +6,7 @@ on:
       - "mcp-v*"
       - "sdk-js-v*"
       - "ai-sdk-v*"
+      - "connect-js-v*"
   workflow_dispatch:
     inputs:
       package:
@@ -16,6 +17,7 @@ on:
           - mcp-server
           - sdk-js
           - ai-sdk
+          - connect-js
       version:
         description: "Version to publish (e.g. 0.2.1 or 0.2.1-rc.1)"
         required: true
@@ -73,6 +75,10 @@ jobs:
                 PACKAGE_KIND="ai-sdk"
                 VERSION="${TAG#ai-sdk-v}"
                 ;;
+              connect-js-v*)
+                PACKAGE_KIND="connect-js"
+                VERSION="${TAG#connect-js-v}"
+                ;;
               *)
                 echo "Unsupported tag format: $TAG"
                 exit 1
@@ -102,6 +108,10 @@ jobs:
             ai-sdk)
               PACKAGE_NAME="@sardis/ai-sdk"
               PACKAGE_DIR="packages/sardis-ai-sdk"
+              ;;
+            connect-js)
+              PACKAGE_NAME="@sardis/connect"
+              PACKAGE_DIR="packages/sardis-connect-js"
               ;;
             *)
               echo "Unsupported package input: $PACKAGE_KIND"

--- a/.github/workflows/release-python-integrations.yml
+++ b/.github/workflows/release-python-integrations.yml
@@ -7,6 +7,7 @@ on:
       - "py-crewai-v*"
       - "py-adk-v*"
       - "py-agent-sdk-v*"
+      - "py-connect-v*"
   workflow_dispatch:
     inputs:
       package:
@@ -18,6 +19,7 @@ on:
           - sardis-crewai
           - sardis-adk
           - sardis-agent-sdk
+          - sardis-connect
       version:
         description: "Version to publish (e.g. 0.1.0 or 0.1.0rc1)"
         required: true
@@ -87,6 +89,12 @@ jobs:
                 PACKAGE_DIR="packages/sardis-agent-sdk"
                 IMPORT_NAME="sardis_agent_sdk"
                 VERSION="${TAG#py-agent-sdk-v}"
+                ;;
+              py-connect-v*)
+                PACKAGE="sardis-connect"
+                PACKAGE_DIR="packages/sardis-connect"
+                IMPORT_NAME="sardis_connect"
+                VERSION="${TAG#py-connect-v}"
                 ;;
               *)
                 echo "Unsupported tag format: $TAG"

--- a/packages/sardis-api/src/sardis_api/main.py
+++ b/packages/sardis-api/src/sardis_api/main.py
@@ -150,6 +150,9 @@ from .routers import mastercard_webhooks as mastercard_webhooks_router
 from .routers import merchant_checkout as merchant_checkout_router
 from .routers import merchants as merchants_router
 from .routers import stripe_connect as stripe_connect_router
+from .routers import service_directory as service_directory_router
+from .routers import compliance_export as compliance_export_router
+from .routers import agent_registry as agent_registry_router
 from .routers import metrics as metrics_router
 from .routers import notifications as notifications_router
 from .routers import offramp as offramp_router
@@ -2143,6 +2146,12 @@ def create_app(settings: SardisSettings | None = None) -> FastAPI:
     )
     app.include_router(merchant_checkout_router.router, prefix="/api/v2/merchant-checkout", tags=["merchant-checkout"])
     app.include_router(merchant_checkout_router.public_router, prefix="/api/v2/merchant-checkout", tags=["merchant-checkout"])
+
+    # --- Service Directory, Compliance Export, Agent Registry ---
+    app.include_router(service_directory_router.router)
+    app.include_router(compliance_export_router.router)
+    app.include_router(agent_registry_router.router)
+    app.include_router(agent_registry_router.public_router)
 
     # --- Delegated payment rails routers ---
     app.include_router(credentials_router.router)

--- a/scripts/deploy-sardis-connect.sh
+++ b/scripts/deploy-sardis-connect.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Sardis Connect — Deploy Script
+# =============================================================================
+#
+# Runs all pending migrations and verifies the deployment.
+#
+# Prerequisites:
+#   1. DATABASE_URL set (Neon connection string)
+#   2. STRIPE_API_KEY set (for Stripe Connect)
+#   3. gcloud auth login (for Cloud Run redeploy)
+#
+# Usage:
+#   export DATABASE_URL="postgresql://..."
+#   ./scripts/deploy-sardis-connect.sh
+#
+# =============================================================================
+set -euo pipefail
+
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║           Sardis Connect — Deploy Script                ║"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+
+# ── Step 1: Check prerequisites ──
+echo "Step 1: Checking prerequisites..."
+
+if [ -z "${DATABASE_URL:-}" ]; then
+    echo "  ERROR: DATABASE_URL not set"
+    echo "  Get it from Neon dashboard: https://console.neon.tech"
+    echo "  export DATABASE_URL='postgresql://...'"
+    exit 1
+fi
+echo "  DATABASE_URL: set (${#DATABASE_URL} chars)"
+
+if [ -z "${STRIPE_API_KEY:-}" ]; then
+    echo "  WARNING: STRIPE_API_KEY not set — Stripe Connect will be disabled"
+else
+    echo "  STRIPE_API_KEY: set"
+fi
+
+echo ""
+
+# ── Step 2: Run migrations ──
+echo "Step 2: Running migrations (102-106)..."
+
+MIGRATIONS_DIR="$(cd "$(dirname "$0")/../packages/sardis-api/migrations" && pwd)"
+
+for migration in 102_stripe_connect 103_checkout_mandate_bridge 104_merchant_website_lookup 105_service_directory 106_agent_registry; do
+    file="$MIGRATIONS_DIR/${migration}.sql"
+    if [ -f "$file" ]; then
+        echo "  Applying: ${migration}.sql ..."
+        psql "$DATABASE_URL" -f "$file" -q 2>&1 || echo "  WARNING: ${migration} may already be applied"
+    else
+        echo "  SKIP: ${migration}.sql not found"
+    fi
+done
+
+echo ""
+
+# ── Step 3: Verify tables exist ──
+echo "Step 3: Verifying new tables..."
+
+for table in stripe_connect_payouts service_directory agent_registry; do
+    exists=$(psql "$DATABASE_URL" -t -A -c "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = '${table}');" 2>/dev/null || echo "false")
+    if [ "$exists" = "t" ]; then
+        echo "  ✓ $table"
+    else
+        echo "  ✗ $table — NOT FOUND"
+    fi
+done
+
+# Verify columns on merchants table
+for col in stripe_account_id mandate_id website; do
+    exists=$(psql "$DATABASE_URL" -t -A -c "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'merchants' AND column_name = '${col}');" 2>/dev/null || echo "false")
+    if [ "$exists" = "t" ]; then
+        echo "  ✓ merchants.${col}"
+    else
+        echo "  ✗ merchants.${col} — NOT FOUND"
+    fi
+done
+
+echo ""
+
+# ── Step 4: Stripe Connect webhook setup reminder ──
+echo "Step 4: Stripe Connect setup"
+echo "  After deploying, configure in Stripe Dashboard:"
+echo "  1. Go to: https://dashboard.stripe.com/test/webhooks"
+echo "  2. Add endpoint: https://api.sardis.sh/api/v2/webhooks/stripe-connect/webhooks"
+echo "  3. Select events: account.updated, payout.paid, payout.failed"
+echo "  4. Check: 'Listen to events on Connected accounts'"
+echo "  5. Copy webhook secret → set SARDIS_STRIPE_CONNECT_WEBHOOK_SECRET"
+echo ""
+
+# ── Step 5: Cloud Run redeploy ──
+echo "Step 5: Cloud Run redeploy"
+if command -v gcloud &> /dev/null; then
+    echo "  To redeploy API with new env vars:"
+    echo "  gcloud run services update sardis-api-staging \\"
+    echo "    --region us-central1 \\"
+    echo "    --update-env-vars SARDIS_STRIPE_CONNECT_WEBHOOK_SECRET=your_secret_here"
+else
+    echo "  gcloud not found — install Google Cloud SDK"
+fi
+
+echo ""
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║           Deploy complete! Verify at:                    ║"
+echo "║   https://api.sardis.sh/api/v2/docs                     ║"
+echo "╚══════════════════════════════════════════════════════════╝"


### PR DESCRIPTION
## Summary

- Wire 3 new routers into main.py: service directory, compliance export, agent registry
- Deploy script for Sardis Connect (migrations 102-106 + Stripe webhook setup)
- Publish workflow updates: sardis-connect (PyPI) + @sardis/connect (npm)

## Deploy Checklist

After merge:
1. `gcloud auth login`
2. `export DATABASE_URL=...` (from Neon dashboard)  
3. `./scripts/deploy-sardis-connect.sh`
4. Configure Stripe Connect webhook in Stripe Dashboard
5. Tag `py-connect-v0.1.0` to publish sardis-connect to PyPI
6. Tag `connect-js-v0.1.0` to publish @sardis/connect to npm

## Test plan
- [x] 109/109 tests passing
- [x] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)