### PR TITLE
fix(landing): avoid sync effect state updates

### DIFF
--- a/apps/landing/app/landing/page.tsx
+++ b/apps/landing/app/landing/page.tsx
@@ -1,29 +1,11 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import { useEffect, useState } from "react"
 import { useTheme } from "next-themes"
 import { Plus_Jakarta_Sans } from "next/font/google"
-import { motion } from "framer-motion"
 import Link from "next/link"
 
 const jakarta = Plus_Jakarta_Sans({ subsets: ["latin"], variable: "--font-jakarta" })
-
-/* ── Scroll-triggered fade-up ── */
-function useInView() {
-  const ref = useRef<HTMLElement>(null)
-  const [inView, setInView] = useState(false)
-  useEffect(() => {
-    const el = ref.current
-    if (!el) return
-    const obs = new IntersectionObserver(
-      ([entry]) => { if (entry.isIntersecting) { setInView(true); obs.disconnect() } },
-      { threshold: 0.1 }
-    )
-    obs.observe(el)
-    return () => obs.disconnect()
-  }, [])
-  return { ref, inView }
-}
 
 function Section({ children, className, ...props }: React.HTMLAttributes<HTMLElement>) {
   return (
@@ -199,7 +181,10 @@ function BezelCard({ children, t }: { children: React.ReactNode; t: typeof light
 export default function LandingPage() {
   const { resolvedTheme, setTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
-  useEffect(() => setMounted(true), [])
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setMounted(true))
+    return () => cancelAnimationFrame(frame)
+  }, [])
 
   const isDark = mounted && resolvedTheme === "dark"
   const t = isDark ? dark : light

--- a/apps/landing/app/pricing/page.tsx
+++ b/apps/landing/app/pricing/page.tsx
@@ -110,7 +110,10 @@ function SardisLogo({ color, size = 20 }: { color: string; size?: number }) {
 export default function PricingPage() {
   const { resolvedTheme, setTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
-  useEffect(() => setMounted(true), [])
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setMounted(true))
+    return () => cancelAnimationFrame(frame)
+  }, [])
   const isDark = mounted && resolvedTheme === "dark"
   const t = isDark ? dark : light
 

--- a/apps/landing/components/cookie-consent.tsx
+++ b/apps/landing/components/cookie-consent.tsx
@@ -17,7 +17,10 @@ export function CookieConsent() {
   const [visible, setVisible] = useState(false)
 
   useEffect(() => {
-    if (getCookieConsent() === null) setVisible(true)
+    const frame = requestAnimationFrame(() => {
+      if (getCookieConsent() === null) setVisible(true)
+    })
+    return () => cancelAnimationFrame(frame)
   }, [])
 
   const decide = (value: CookieConsentValue) => {


### PR DESCRIPTION
## Summary
- fix the landing lint blocker that was keeping Dependabot PRs open despite auto-merge being enabled
- replace synchronous effect setState calls with requestAnimationFrame scheduling
- remove unused landing page motion/useInView code

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @sardis/app-landing lint
- pnpm --filter @sardis/app-landing build

## Notes
- Local Node is v24.10.0 while the repo declares Node 22.x; pnpm emitted an engine warning but lint and build completed successfully.