### PR TITLE
fix(landing): redirect apex manifesto

### DIFF
--- a/apps/landing/next.config.ts
+++ b/apps/landing/next.config.ts
@@ -4,6 +4,15 @@ const nextConfig: NextConfig = {
   experimental: {
     externalDir: true,
   },
+  async redirects() {
+    return [
+      {
+        source: "/manifesto",
+        destination: "https://www.sardis.sh/manifesto",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,13 @@
       ]
     }
   ],
+  "redirects": [
+    {
+      "source": "/manifesto",
+      "destination": "https://www.sardis.sh/manifesto",
+      "permanent": true
+    }
+  ],
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/$1" }
   ]


### PR DESCRIPTION
## Summary
- redirect /manifesto on the apex landing deployment to https://www.sardis.sh/manifesto
- add both root Vercel and Next.js landing redirects so the fix works whether Vercel uses the repo root config or the app config

## Verification
- curl -I -L https://sardis.sh/manifesto currently returns 404 before this fix
- curl -I -L https://www.sardis.sh/manifesto returns 200
- python3 -m json.tool vercel.json
- pnpm --filter @sardis/app-landing build

## Expected after deploy
- https://sardis.sh/manifesto returns a redirect to https://www.sardis.sh/manifesto
- https://www.sardis.sh/manifesto remains 200