### PR TITLE
fix(ci): use Scorecard action commit pin

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+      - uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- replace the OpenSSF Scorecard action tag-object SHA with the actual upstream v2.4.0 commit SHA
- fixes main push failures where Scorecard publish rejected the workflow as an imposter commit

## Verification
- `git diff --check`
- verified `62b2cac7ed8198b15735ed49ab1e5cf35480ba46` resolves to the upstream `ossf/scorecard-action` v2.4.0 release commit via GitHub API

After merge, the main-branch OpenSSF Scorecard workflow should publish successfully instead of failing with workflow verification.