### PR TITLE
fix(ci): stop publishing Scorecard web results

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true
+          publish_results: false
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:


### PR DESCRIPTION
## Summary
- disable OpenSSF Scorecard webapp publishing
- keep Scorecard SARIF generation, artifact upload, and GitHub code scanning upload

## Why
The current red check is failing after Scorecard analysis during the external webapp publish/signature verification step, not during local SARIF generation. Disabling publish avoids that external verification failure while preserving the repo-local security output.

## Verification
- git diff --check