### PR TITLE
Give manifesto page a sepia treatment

### DIFF
--- a/apps/canvas-site/src/pages/manifesto.astro
+++ b/apps/canvas-site/src/pages/manifesto.astro
@@ -5,6 +5,31 @@ const styles = `
   @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap');
 
   body[data-canvas="manifesto"] {
+    --background: #efe1bf;
+    --foreground: #2a1d12;
+    --card: #f6e9cb;
+    --card-elevated: #fbf0d6;
+    --popover: #f6e9cb;
+    --text-primary: #21160d;
+    --text-secondary: #4a3523;
+    --text-muted: #73583d;
+    --text-faint: rgba(42, 29, 18, 0.52);
+    --text-ghost: rgba(42, 29, 18, 0.32);
+    --text-label: rgba(42, 29, 18, 0.58);
+    --border: #c7ad7b;
+    --border-strong: #9d7d4c;
+    --border-subtle: rgba(80, 52, 30, 0.16);
+    --primary: #70441f;
+    --primary-fg: #fff4d7;
+    --muted: #e4d0a6;
+    --accent: #d6bb85;
+    --shadow-sm: 0 1px 2px rgba(70, 43, 21, 0.08);
+    --shadow-md: 0 2px 8px rgba(70, 43, 21, 0.1);
+    --shadow-lg: 0 8px 24px rgba(70, 43, 21, 0.12);
+    background:
+      radial-gradient(circle at 50% 0%, rgba(255, 246, 219, 0.72), transparent 34rem),
+      var(--background);
+    color: var(--text-primary);
     font-family: 'Manrope', ui-sans-serif, system-ui, -apple-system, sans-serif;
   }
   body[data-canvas="manifesto"] .manifesto,


### PR DESCRIPTION
### Motivation
- Provide a warmer, sepia reading treatment for the manifesto canvas so the page reads like a printed/archival essay. 
- Keep the change scoped to the manifesto canvas only to avoid affecting other site canvases.

### Description
- Add a manifesto-scoped sepia token set by injecting CSS variables under `body[data-canvas="manifesto"]` in `apps/canvas-site/src/pages/manifesto.astro` to override background, surfaces, text, borders, accents, and shadows. 
- Apply a subtle warm radial gradient background layered above the new sepia `--background` to give the page a gentle vignette. 
- Preserve existing manifesto typography and layout by only changing color and surface tokens in the manifesto scope.

### Testing
- Ran `pnpm --filter canvas-site build`, which completed successfully and produced the static site (28 pages), with only a Node engine version warning about `node: 22.x` vs the runtime `v24.x`. 
- Ran `pnpm --filter canvas-site preview -- --host 127.0.0.1 --port 4321`, which started the local preview server successfully. 
- Ran `git diff --check`, which returned clean results for the modified file. 
- Attempted an automated visual check using Puppeteer to capture a screenshot, but Chromium failed to launch due to a missing system library (`libatk-1.0.so.0`), so the screenshot verification did not complete. 
- Attempted to run `pnpm dlx vercel --version` and `npx --yes vercel --version` to install the Vercel CLI for redeploy, but both failed due to `403 Forbidden` responses from the npm registry, preventing an automated redeploy from this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ed579d7083249636728a9435a496)