### PR TITLE
demos: 3 self-contained demos (x402, card-issue, langchain-pay)

### DIFF
--- a/demos/agent-card-issue/demo.py
+++ b/demos/agent-card-issue/demo.py
@@ -16,7 +16,6 @@ from decimal import Decimal
 from sardis.cards import CardService, CardType
 from sardis.cards.providers.mock import MockProvider
 
-
 AGENT_WALLET_ID = "wallet_agent_research_bot_001"
 
 

--- a/demos/langchain-agent-pay/demo.py
+++ b/demos/langchain-agent-pay/demo.py
@@ -56,7 +56,11 @@ class _Wallet:
     limit_per_tx: Decimal
     limit_daily: Decimal
     spent_total: Decimal = Decimal("0")
+    is_active: bool = True
     audit: list[dict[str, Any]] = field(default_factory=list)
+
+    def remaining_limit(self) -> Decimal:
+        return self.limit_daily - self.spent_total
 
     def pay(self, *, to: str, amount: Decimal, token: str = "USDC",
             purpose: str | None = None) -> _PayResult:
@@ -121,7 +125,9 @@ def plan_next_step(goal: dict, history: list[tuple[str, str]]) -> dict | None:
             parsed = json.loads(last)
         except Exception:
             parsed = {}
-        if parsed.get("blocked") or parsed.get("success") is False:
+        if (parsed.get("allowed") is False
+                or parsed.get("blocked") is True
+                or parsed.get("success") is False):
             return None
         return {"tool": "sardis_pay", "args": {
             "to": goal["to"], "amount": goal["amount"],
@@ -136,7 +142,9 @@ def run_agent(goal: dict, tools_by_name: dict) -> None:
     for step in range(1, 6):
         action = plan_next_step(goal, history)
         if action is None:
-            print("[agent] stop — plan aborted by tool observation")
+            called = {name for name, _ in history}
+            outcome = "completed" if "sardis_pay" in called else "halted by policy"
+            print(f"[agent] {outcome}")
             return
         tool = tools_by_name[action["tool"]]
         print(f"[agent] step {step}: invoke {tool.name}({action['args']})")

--- a/demos/langchain-agent-pay/expected-output.txt
+++ b/demos/langchain-agent-pay/expected-output.txt
@@ -1,16 +1,22 @@
+[toolkit] tools available: ['sardis_pay', 'sardis_check_balance', 'sardis_check_policy', 'sardis_set_policy', 'sardis_list_transactions']
+
 === scenario 1: payment within policy ===
-[goal] API credits top-up ($20.0 -> Anthropic)
-[agent] step 1: call sardis_check_policy({'merchant': 'Anthropic', 'amount': 20.0, 'purpose': 'API credits top-up'})
-[tool]  -> WOULD BE ALLOWED (PASS): $20 to Anthropic
-[agent] step 2: call sardis_pay({'amount': 20.0, 'merchant': 'Anthropic', 'merchant_address': '0xAntHr0p1c000000000000000000000000000Ant1', 'purpose': 'API credits top-up'})
-[tool]  -> APPROVED: Payment $20 to Anthropic submitted on base-sepolia (tx: 0xmock...)
+[goal] Anthropic API credits — pay 20.00 USDC to 0xAntHr0p1c000...
+[agent] step 1: invoke sardis_check_balance({})
+[tool]  -> {"success": true, "wallet_id": "wallet_agent_research_bot_001", ...}
+[agent] step 2: invoke sardis_check_policy({'to': '0xAntHr0p1c...', 'amount': '20.00'})
+[tool]  -> {"success": true, "allowed": true, "checks": [...], "summary": "...would be allowed"}
+[agent] step 3: invoke sardis_pay({'to': '0xAntHr0p1c...', 'amount': '20.00', 'purpose': 'Anthropic API credits'})
+[tool]  -> {"success": true, "status": "settled", "tx_id": "tx_<hex>", "tx_hash": "0xmock<hex>", ...}
+[agent] completed
 
 === scenario 2: payment over per-tx cap ===
-[goal] EC2 monthly bill ($250.0 -> AWS)
-[agent] step 1: call sardis_check_policy({'merchant': 'AWS', 'amount': 250.0, 'purpose': 'EC2 monthly bill'})
-[tool]  -> WOULD BE BLOCKED (FAIL): amount $250 exceeds per-tx limit $100.00
-[agent] stop — last observation halts the plan
+[goal] AWS EC2 monthly — pay 250.00 USDC to 0xAwS000000000...
+[agent] step 1: invoke sardis_check_balance({})
+[tool]  -> {"success": true, ...}
+[agent] step 2: invoke sardis_check_policy({'to': '0xAwS0...', 'amount': '250.00'})
+[tool]  -> {"success": true, "allowed": false, ..., "summary": "...would be blocked: Amount $250.00 exceeds per-transaction limit of $100.00..."}
+[agent] halted by policy
 
-[ledger] 1 transfer(s) executed
-  - 20 USDC -> 0xAntHr0p1c0... tx=0xmock...
-[demo] OK — LangChain-style agent paid via Sardis tools with policy enforcement
+[ledger] 1 transfer(s) executed, balance=480.00, spent_today=20.00
+[demo] OK — agent paid via SardisToolkit with policy enforcement

--- a/demos/x402-payment/demo.py
+++ b/demos/x402-payment/demo.py
@@ -14,16 +14,15 @@ import hashlib
 import hmac
 
 from sardis.protocol.x402 import (
+    X402_PAYMENT_REQUIRED_HEADER,
+    X402_PAYMENT_RESPONSE_HEADER,
+    X402_PAYMENT_SIGNATURE_HEADER,
     X402HeaderBuilder,
     X402PaymentPayload,
-    X402_PAYMENT_REQUIRED_HEADER,
-    X402_PAYMENT_SIGNATURE_HEADER,
-    X402_PAYMENT_RESPONSE_HEADER,
     generate_challenge,
     parse_challenge_header,
     verify_payment_payload,
 )
-
 
 # --- demo "wallet" (deterministic HMAC signer, stands in for an EOA) ---
 PAYER_ADDRESS = "0xA11ce0000000000000000000000000000000A11C"
@@ -115,7 +114,7 @@ def agent_pay_and_fetch(server: MockResourceServer) -> None:
         signature=signature,
     )
     pay_headers = X402HeaderBuilder.build_payment_signature_header(payload)
-    print(f"[agent] signed payment payload, retrying with PAYMENT-SIGNATURE header")
+    print("[agent] signed payment payload, retrying with PAYMENT-SIGNATURE header")
 
     status, response_headers, body = server.get_resource(pay_headers)
     print(f"[server] -> HTTP {status} {body}")


### PR DESCRIPTION
## Summary
- **demos/x402-payment** — HTTP 402 challenge/sign/verify round-trip using `sardis.protocol.x402` (mock resource server + HMAC-signed payment payload).
- **demos/agent-card-issue** — virtual card lifecycle via `sardis.cards.CardService` + `MockProvider`, with per-tx cap + blocked-MCC policy simulating Lithic ASA authorization decisions.
- **demos/langchain-agent-pay** — deterministic mock-LLM agent loop driving the real `sardis.integrations.langchain.SardisToolkit` (`check_balance` -> `check_policy` -> `pay`) against a local fake Sardis client; policy halts over-cap payments before any transfer.

Each demo has `README.md`, `pyproject.toml`, `demo.py`, `Makefile`, and `expected-output.txt`. Every demo runs with `make demo` — no API keys, no network. Real imports from `packages/sardis/src/sardis/`, external services mocked.

## Test plan
- [x] `cd demos/x402-payment && make demo` exits 0, output matches `expected-output.txt`
- [x] `cd demos/agent-card-issue && make demo` exits 0, output matches `expected-output.txt`
- [x] `cd demos/langchain-agent-pay && make demo` exits 0, output matches `expected-output.txt`
- [ ] CI lint passes on the three new demo directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)