### PR TITLE
chore(oss): drop dead .vercelignore entry

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,4 +1,3 @@
-packages/sardis-solana-program/.anchor/test-ledger
 contracts/out
 contracts/cache
 contracts/lib


### PR DESCRIPTION
Removes the dead `packages/sardis-solana-program/.anchor/test-ledger` ignore line — that package no longer exists in the public repo. Final root-surface tidy; the rest of the root files are all legitimate (workspace manifests, license/docs, gitleaks/pre-commit, landing deploy config, public-only .gitmodules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)