### PR TITLE
fix(sdk): call real resource methods in agent-framework adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -296,6 +296,8 @@ gv-team.md
 .windsurf/
 .zencoder/
 skills/
+!packages/sardis-openclaw/skills/
+!packages/sardis-openclaw/skills/**
 skills-lock.json
 AGENTS.md
 

--- a/packages/sardis-js/__tests__/integrations.test.ts
+++ b/packages/sardis-js/__tests__/integrations.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSardisTools } from '../src/langchain/index.js';
+import type { Sardis } from '../src/index.js';
+import type { LangChainStructuredTool } from '../src/langchain/index.js';
+
+// Regression for the `as unknown as { ... }` casts that called resource
+// methods which did not exist or had the wrong signature (getBalance with an
+// object arg, policies.applyFromNaturalLanguage, transactions.list, etc.).
+// These compiled because the casts suppressed type-checking but failed at
+// runtime. Removing the casts lets tsc validate the calls; these tests pin the
+// argument shapes so a future regression is caught at runtime too.
+
+function fakeClient() {
+  return {
+    wallets: { getBalance: vi.fn().mockResolvedValue({ balance: '10' }) },
+    policies: {
+      check: vi.fn().mockResolvedValue({ allowed: true }),
+      apply: vi.fn().mockResolvedValue({ ok: true }),
+    },
+    ledger: { listEntries: vi.fn().mockResolvedValue([]) },
+  };
+}
+
+function tool(tools: LangChainStructuredTool[], name: string): LangChainStructuredTool {
+  const t = tools.find((x) => x.name === name);
+  if (!t) throw new Error(`tool ${name} not found`);
+  return t;
+}
+
+function build(client: ReturnType<typeof fakeClient>, agentId?: string) {
+  return createSardisTools({
+    client: client as unknown as Sardis,
+    walletId: 'wal_1',
+    apiKey: 'test',
+    ...(agentId ? { agentId } : {}),
+  });
+}
+
+describe('langchain adapter binds to real resource methods', () => {
+  it('check_balance calls wallets.getBalance(walletId, chain, token) positionally', async () => {
+    const c = fakeClient();
+    await tool(build(c), 'sardis_check_balance').invoke({ token: 'EURC', chain: 'tempo' });
+    expect(c.wallets.getBalance).toHaveBeenCalledWith('wal_1', 'tempo', 'EURC');
+  });
+
+  it('check_balance falls back to default chain/token', async () => {
+    const c = fakeClient();
+    await tool(build(c), 'sardis_check_balance').invoke({});
+    expect(c.wallets.getBalance).toHaveBeenCalledWith('wal_1', 'base', 'USDC');
+  });
+
+  it('check_policy calls policies.check with the real {agent_id, amount, merchant_id} shape', async () => {
+    const c = fakeClient();
+    await tool(build(c, 'agt_1'), 'sardis_check_policy').invoke({ amount: '5', to: 'merchant.example' });
+    expect(c.policies.check).toHaveBeenCalledWith({
+      agent_id: 'agt_1',
+      amount: '5',
+      merchant_id: 'merchant.example',
+    });
+  });
+
+  it('set_policy calls policies.apply(natural_language, agent_id)', async () => {
+    const c = fakeClient();
+    await tool(build(c, 'agt_1'), 'sardis_set_policy').invoke({ policy: 'max $50 per day' });
+    expect(c.policies.apply).toHaveBeenCalledWith('max $50 per day', 'agt_1');
+  });
+
+  it('list_transactions calls ledger.listEntries (transactions.list never existed)', async () => {
+    const c = fakeClient();
+    await tool(build(c), 'sardis_list_transactions').invoke({ limit: 5 });
+    expect(c.ledger.listEntries).toHaveBeenCalledWith({ wallet_id: 'wal_1', limit: 5 });
+  });
+});

--- a/packages/sardis-js/src/ai-sdk/index.ts
+++ b/packages/sardis-js/src/ai-sdk/index.ts
@@ -240,10 +240,7 @@ export function createSardis(opts: CreateSardisOptions): SardisProvider {
       execute: async (args) => {
         const input = HoldCaptureSchema.parse(args);
         return wrap('hold_capture', input, () =>
-          (client.holds as unknown as { capture: (id: string, body: Record<string, unknown>) => Promise<unknown> }).capture(
-            input.holdId,
-            input.amount ? { amount: input.amount } : {},
-          ),
+          client.holds.capture(input.holdId, input.amount),
         );
       },
     },
@@ -252,9 +249,7 @@ export function createSardis(opts: CreateSardisOptions): SardisProvider {
       parameters: HoldVoidSchema,
       execute: async (args) => {
         const input = HoldVoidSchema.parse(args);
-        return wrap('hold_void', input, () =>
-          (client.holds as unknown as { void: (id: string) => Promise<unknown> }).void(input.holdId),
-        );
+        return wrap('hold_void', input, () => client.holds.void(input.holdId));
       },
     },
     sardis_get_balance: {
@@ -263,12 +258,7 @@ export function createSardis(opts: CreateSardisOptions): SardisProvider {
       execute: async (args) => {
         const input = BalanceSchema.parse(args);
         return wrap('balance', input, () =>
-          (client.wallets as unknown as {
-            getBalance: (id: string, params: Record<string, unknown>) => Promise<unknown>;
-          }).getBalance(walletId, {
-            ...(input.token ? { token: input.token } : {}),
-            ...(input.chain ? { chain: input.chain } : {}),
-          }),
+          client.wallets.getBalance(walletId, input.chain ?? 'base', input.token ?? 'USDC'),
         );
       },
     },
@@ -278,12 +268,11 @@ export function createSardis(opts: CreateSardisOptions): SardisProvider {
       execute: async (args) => {
         const input = PolicyCheckSchema.parse(args);
         return wrap('policy_check', input, () =>
-          (client.policies as unknown as {
-            check: (body: Record<string, unknown>) => Promise<unknown>;
-          }).check({
+          client.policies.check({
+            agent_id: opts.agentId ?? '',
             amount: input.amount,
-            ...(input.merchant ? { merchant: input.merchant } : {}),
-            ...(input.category ? { category: input.category } : {}),
+            ...(input.merchant ? { merchant_id: input.merchant } : {}),
+            ...(input.category ? { merchant_category: input.category } : {}),
           }),
         );
       },

--- a/packages/sardis-js/src/langchain/index.ts
+++ b/packages/sardis-js/src/langchain/index.ts
@@ -120,12 +120,7 @@ export function createSardisTools(opts: CreateSardisToolsOptions): LangChainStru
       invoke: (input) => {
         const parsed = CheckBalanceSchema.parse(input);
         return safe(() =>
-          (client.wallets as unknown as {
-            getBalance: (id: string, params: Record<string, unknown>) => Promise<unknown>;
-          }).getBalance(walletId, {
-            ...(parsed.token ? { token: parsed.token } : {}),
-            ...(parsed.chain ? { chain: parsed.chain } : {}),
-          }),
+          client.wallets.getBalance(walletId, parsed.chain ?? 'base', parsed.token ?? 'USDC'),
         );
       },
     },
@@ -137,12 +132,10 @@ export function createSardisTools(opts: CreateSardisToolsOptions): LangChainStru
       invoke: (input) => {
         const parsed = CheckPolicySchema.parse(input);
         return safe(() =>
-          (client.policies as unknown as {
-            check: (body: Record<string, unknown>) => Promise<unknown>;
-          }).check({
+          client.policies.check({
+            agent_id: opts.agentId ?? '',
             amount: parsed.amount,
-            ...(parsed.token ? { token: parsed.token } : {}),
-            merchant: parsed.to,
+            ...(parsed.to ? { merchant_id: parsed.to } : {}),
           }),
         );
       },
@@ -155,12 +148,7 @@ export function createSardisTools(opts: CreateSardisToolsOptions): LangChainStru
       invoke: (input) => {
         const parsed = SetPolicySchema.parse(input);
         return safe(() =>
-          (client.policies as unknown as {
-            applyFromNaturalLanguage: (body: Record<string, unknown>) => Promise<unknown>;
-          }).applyFromNaturalLanguage({
-            policy: parsed.policy,
-            ...(opts.agentId ? { agent_id: opts.agentId } : {}),
-          }),
+          client.policies.apply(parsed.policy, opts.agentId ?? ''),
         );
       },
     },
@@ -171,9 +159,7 @@ export function createSardisTools(opts: CreateSardisToolsOptions): LangChainStru
       invoke: (input) => {
         const parsed = ListTransactionsSchema.parse(input);
         return safe(() =>
-          (client.transactions as unknown as {
-            list: (params: Record<string, unknown>) => Promise<unknown>;
-          }).list({ wallet_id: walletId, limit: parsed.limit ?? 20 }),
+          client.ledger.listEntries({ wallet_id: walletId, limit: parsed.limit ?? 20 }),
         );
       },
     },

--- a/packages/sardis-js/src/mastra/index.ts
+++ b/packages/sardis-js/src/mastra/index.ts
@@ -126,9 +126,7 @@ export function createSardisMastraTools(
       inputSchema: HoldCaptureSchema,
       execute: async ({ context }) => {
         const input = HoldCaptureSchema.parse(context);
-        return (client.holds as unknown as {
-          capture: (id: string, body: Record<string, unknown>) => Promise<unknown>;
-        }).capture(input.holdId, input.amount ? { amount: input.amount } : {});
+        return client.holds.capture(input.holdId, input.amount);
       },
     },
     sardis_void_hold: {
@@ -137,9 +135,7 @@ export function createSardisMastraTools(
       inputSchema: HoldVoidSchema,
       execute: async ({ context }) => {
         const input = HoldVoidSchema.parse(context);
-        return (client.holds as unknown as { void: (id: string) => Promise<unknown> }).void(
-          input.holdId,
-        );
+        return client.holds.void(input.holdId);
       },
     },
     sardis_get_balance: {
@@ -148,12 +144,7 @@ export function createSardisMastraTools(
       inputSchema: BalanceSchema,
       execute: async ({ context }) => {
         const input = BalanceSchema.parse(context);
-        return (client.wallets as unknown as {
-          getBalance: (id: string, params: Record<string, unknown>) => Promise<unknown>;
-        }).getBalance(walletId, {
-          ...(input.token ? { token: input.token } : {}),
-          ...(input.chain ? { chain: input.chain } : {}),
-        });
+        return client.wallets.getBalance(walletId, input.chain ?? 'base', input.token ?? 'USDC');
       },
     },
     sardis_check_policy: {
@@ -162,12 +153,11 @@ export function createSardisMastraTools(
       inputSchema: PolicyCheckSchema,
       execute: async ({ context }) => {
         const input = PolicyCheckSchema.parse(context);
-        return (client.policies as unknown as {
-          check: (body: Record<string, unknown>) => Promise<unknown>;
-        }).check({
+        return client.policies.check({
+          agent_id: opts.agentId ?? '',
           amount: input.amount,
-          ...(input.merchant ? { merchant: input.merchant } : {}),
-          ...(input.category ? { category: input.category } : {}),
+          ...(input.merchant ? { merchant_id: input.merchant } : {}),
+          ...(input.category ? { merchant_category: input.category } : {}),
         });
       },
     },

--- a/packages/sardis-openclaw/skills/audit/SKILL.md
+++ b/packages/sardis-openclaw/skills/audit/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sardis-audit
+description: Teach an OpenClaw agent to inspect Sardis transactions, preserve evidence, and verify authority before reporting payment state.
+homepage: https://sardis.sh
+user-invocable: false
+---
+
+# Sardis Audit
+
+Use this skill only when `SARDIS_API_KEY` is present. If it is missing, state that Sardis audit data is unavailable.
+
+## Audit Flow
+
+Use `sardis_list_transactions` to inspect the activity ledger before summarizing payment history, card activity, or budget usage.
+
+Use `sardis_check_balance` before claiming available spend capacity.
+
+Use `sardis_check_policy` before saying a future spend is allowed.
+
+## Reporting Rules
+
+Report Sardis transaction identifiers, status, merchant, amount, currency, and evidence references when available.
+
+Distinguish `pending`, `requires_approval`, `denied`, `settled`, and `revoked` states.
+
+Never claim a payment completed from intent text alone. The ledger status is the source of truth.

--- a/packages/sardis-openclaw/skills/payments/SKILL.md
+++ b/packages/sardis-openclaw/skills/payments/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: sardis-payments
+description: Teach an OpenClaw agent to use Sardis payment verbs with policy checks, reversibility awareness, and fail-closed handling.
+homepage: https://sardis.sh
+user-invocable: false
+---
+
+# Sardis Payments
+
+Use this skill only when `SARDIS_API_KEY` is present. If it is missing, do not create wallets, issue cards, or attempt payments.
+
+## Payment Verbs
+
+Use `sardis_give_wallet` to provision the agent payment identity.
+
+Use `sardis_spend` only after a successful `sardis_check_policy` result.
+
+Use `sardis_pay_invoice` for invoice-shaped requests instead of manually constructing a payment when invoice metadata is available.
+
+Use `sardis_issue_card` only when the user has explicitly requested a card and the policy result permits it.
+
+Use `sardis_freeze_card` when a card is revoked, compromised, outside mandate, or no longer needed.
+
+## Fail-Closed Rules
+
+If Sardis returns `requires_approval`, surface the approval requirement and wait.
+
+If Sardis returns `deny`, stop the payment path.
+
+If Sardis is unavailable, treat the action as denied until the service is reachable again.
+
+Never expose raw card data, private keys, API keys, signing secrets, or provider tokens.

--- a/packages/sardis-openclaw/skills/spending-policy/SKILL.md
+++ b/packages/sardis-openclaw/skills/spending-policy/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sardis-spending-policy
+description: Teach an OpenClaw agent to set budgets, check policy before spend, and honor Sardis allow / requires_approval / deny outcomes.
+homepage: https://sardis.sh
+user-invocable: false
+---
+
+# Sardis Spending Policy
+
+Use this skill only when `SARDIS_API_KEY` is present. If it is missing, stop and ask the operator to configure Sardis before attempting any money movement.
+
+## Required Flow
+
+1. Create or update a budget with `sardis_set_budget` before the first spend.
+2. Run `sardis_check_policy` before every `sardis_spend`.
+3. Continue only when the policy result is `allow`.
+4. Pause when the result is `requires_approval`.
+5. Refuse when the result is `deny`.
+
+## Guardrails
+
+Never infer authority from user wording alone. The Sardis policy result is the authority boundary.
+
+Never split one payment into smaller payments to bypass a budget, approval threshold, merchant block, token block, or time window.
+
+Never retry a denied action with changed fields unless the operator explicitly changes the budget or mandate first.


### PR DESCRIPTION
The langchain, ai-sdk, and mastra adapters used `as unknown as { ... }` casts to invoke resource methods that had the wrong signature or did not exist. The casts suppressed type-checking, so the calls compiled but would fail at runtime:

- `wallets.getBalance` called with an object 2nd arg — real: `getBalance(walletId, chain, token)`.
- `policies.check` passed `{merchant, token}` — real input: `{agent_id, amount, merchant_id, merchant_category, ...}`.
- `policies.applyFromNaturalLanguage` does not exist — real: `apply(natural_language, agent_id)`.
- `holds.capture` passed `{amount}` — real: `capture(holdId, amount?)`.
- `transactions.list` does not exist — recent activity lives in `ledger.listEntries({ wallet_id, limit })`.

Removing the casts lets `tsc` validate the calls. Adds a regression test pinning the argument shapes. tsc clean; 24 tests pass (5 new).

Surfaced by the ponytail×deslop minimization audit (deslop lens caught the casts; these were latent runtime bugs, not style).